### PR TITLE
Update brightness-sync.service

### DIFF
--- a/brightness-sync.service
+++ b/brightness-sync.service
@@ -5,7 +5,7 @@ StartLimitIntervalSec=0[Service]
 Type=simple
 Restart=always
 RestartSec=1
-ExecStart=/change/this/path/to/duo watch-backlight
+ExecStart=/usr/bin/env /change/this/path/to/duo watch-backlight
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
this small change improves compatibility, prior to this the service would not start under fedora.