### PR TITLE
Watch screens enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Features:
 
 `duo set-tablet-mapping` will set necessary dconf settings, but for them to work you need a Mutter with a patch from https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/3556 and libwacom with this patch https://github.com/linuxwacom/libwacom/pull/640 . Both are merged upstream, so you can just wait.
 
+## watch screens startup application
+
+On most linux distros you can copy watch-screens.desktop that just needs `/path/to/duo` changed before moving it to `~/.config/autostart` to enable automatic keyboard detection and screen orientation in the background.  Be sure to `chmod +x watch-screens.desktop` then log out and back on.
+
 ## bottom screen toggle on GNOME
 
 Install https://github.com/jadahl/gnome-monitor-config. I packaged it for NixOS already, see https://github.com/NixOS/nixpkgs/pull/290444.

--- a/brightness-sync.service
+++ b/brightness-sync.service
@@ -5,7 +5,7 @@ StartLimitIntervalSec=0[Service]
 Type=simple
 Restart=always
 RestartSec=1
-ExecStart=/change/this/path/to/duo watch-backlight
+ExecStart=/usr/bin/env /change/this/path/to/duo watch-backlight
 
 [Install]
 WantedBy=multi-user.target

--- a/brightness-sync.service
+++ b/brightness-sync.service
@@ -5,7 +5,7 @@ StartLimitIntervalSec=0[Service]
 Type=simple
 Restart=always
 RestartSec=1
-ExecStart=/usr/bin/env /change/this/path/to/duo watch-backlight
+ExecStart=/change/this/path/to/duo watch-backlight
 
 [Install]
 WantedBy=multi-user.target

--- a/duo
+++ b/duo
@@ -145,7 +145,7 @@ case "$1" in
         fi
       fi
       neworientation=$(gdbus call --system --dest net.hadess.SensorProxy --object-path /net/hadess/SensorProxy --method org.freedesktop.DBus.Properties.Get net.hadess.SensorProxy AccelerometerOrientation |  sed "s/.*<'\([^']*\)'>.*/\1/")
-      echo "keyboard:" $keyboard " screens:" $screens " orientation:" $orientation
+      # echo "keyboard:" $keyboard " screens:" $screens " orientation:" $orientation
       if [[ "$orientation" != "$neworientation" && "$keyboard" == false ]]; then
         orientation="$neworientation"
         "$0" $orientation 

--- a/duo
+++ b/duo
@@ -115,5 +115,43 @@ case "$1" in
       stdbuf -oL sed 's/[ )]//g' |
       xargs -I '{}' duo '{}'
     ;;
+  watch-screens)
+    orientation="normal"
+    screens="top"
+    keyboard=true
+    "$0" $orientation
+    "$0" $screens
+    #"$0" bat-limit
+    #"$0" set-tablet-mapping
+    while true; do
+      if lsusb | grep -q "ASUS Zenbook Duo Keyboard"; then
+        if [[ "$keyboard" == false ]]; then
+          keyboard=true
+          echo "Keyboard found!"
+        fi
+        if [[ "$screens" == "both" ]]; then
+          screens="top"
+          "$0" $screens
+        fi
+      else
+        # If not found, set the variable keyboard to false
+        if [[ "$keyboard" == true ]]; then
+          keyboard=false
+          echo "Keyboard lost!"
+        fi
+        if [[ "$screens" == "top" ]]; then
+          screens="both"
+          "$0" $screens
+        fi
+      fi
+      neworientation=$(gdbus call --system --dest net.hadess.SensorProxy --object-path /net/hadess/SensorProxy --method org.freedesktop.DBus.Properties.Get net.hadess.SensorProxy AccelerometerOrientation |  sed "s/.*<'\([^']*\)'>.*/\1/")
+      echo "keyboard:" $keyboard " screens:" $screens " orientation:" $orientation
+      if [[ "$orientation" != "$neworientation" && "$keyboard" == false ]]; then
+        orientation="$neworientation"
+        "$0" $orientation 
+      fi
+      sleep 0.25
+    done
+    ;;
   *) echo "Usage: duo <top|bottom|both|set-displays|toggle|status|set-tablet-mapping|bat-limit|sync-backlight|watch-backlight|watch-rotation>"
 esac

--- a/watch-screens.desktop
+++ b/watch-screens.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Exec=/usr/bin/env /change/this/path/to/duo watch-screen
+Exec=/usr/bin/env /change/this/path/to/duo watch-screens
 Hidden=false
 NoDisplay=false
 X-GNOME-Autostart-enabled=true

--- a/watch-screens.desktop
+++ b/watch-screens.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Exec=/usr/bin/env /change/this/path/to/duo watch-screen
+Hidden=false
+NoDisplay=false
+X-GNOME-Autostart-enabled=true
+Name=My Login Script
+Comment=Run my custom script at login


### PR DESCRIPTION
whether you just run duo watch-screens or use the .desktop file this automatically handles:
- turning the bottom screen on/off based on the presence of the keyboard
- ignoring the accelerometer and setting the display to top when keyboard is attached
- setting the screens orientation based on the accelerometer
