### PR TITLE
Add watch-displays functionality, to automatically disable/enable bottom screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,27 +13,11 @@ Features:
 
 ## bottom screen toggle on GNOME
 
-Install https://github.com/jadahl/gnome-monitor-config. I packaged it for NixOS already, see https://github.com/NixOS/nixpkgs/pull/290444.
-
-Since WLAN button code is used for keyboard attach/detach events first we need to disable it. Open dconf-editor and edit the key /org/gnome/settings-daemon/plugins/media-keys/rfkill-static and remove XF86WLAN from the list:
-
-<img src="https://github.com/alesya-h/zenbook-duo-2024-ux8406ma-linux/assets/209175/3c24bc19-a22f-44ad-88e9-1c099c88e2c3" width="50%">
-
-You MUST log out and log in again after doing it.
+Make sure gnome-monitor, usbutils and inotify-tools are installed, the script relies on the `gnome-monitor-config`, `lsusb` and `inotifywait` commands from them.
 
 Before the next steps, you may need or want to change the scaling settings or change the config at the top of `duo` based on the version of the duo that you have (1080p vs 3k display models)
 
-After that go to Settings -> Keyboard -> (at the bottom) Keyboard Shortcuts -> View and Customize Shortcuts -> Custom Shortcuts and press +.
-
-* Name: "toggle dualscreen mode" or anything else.
-* Command: `/absolute/path/to/this/repo/duo set-displays`.
-* Shortcut: press "Set Shortcut..." and attach or detach the keyboard (doesn't matter, it sends the same event).
-
-<img src="https://github.com/alesya-h/zenbook-duo-2024-ux8406ma-linux/assets/209175/54d08da6-cba2-49a8-abcf-9eadcd5869d2" width="50%" height="50%">
-
-Press "Add" in the top right corner, close everything and log out and in again. Unlike usual shortcuts, this one doesn't work before logging out.
-
-You also want to add `duo set-displays` to your startup so it'll set your laptop to single or dual screen when you log in.
+For automatic screen management run `duo watch-displays` somewhere at the start of your GNOME session.
 
 For manual screen management there are `duo top`, `duo bottom`, `duo both` and `duo toggle` (toggles between top and both) commands.
 

--- a/duo
+++ b/duo
@@ -27,6 +27,13 @@ function active-external-displays {
 }
 
 case "$1" in
+  watch-displays)
+    while inotifywait -e attrib /dev/bus/usb/001/ ; do
+      if ! external-display-connected; then
+        "$0" normal
+      fi
+    done
+    ;;
   set-displays)
     sleep 1
     if ! external-display-connected; then 
@@ -115,5 +122,5 @@ case "$1" in
       stdbuf -oL sed 's/[ )]//g' |
       xargs -I '{}' stdbuf -oL "$0" '{}'
     ;;
-  *) echo "Usage: duo <top|bottom|both|set-displays|toggle|status|set-tablet-mapping|bat-limit|sync-backlight|watch-backlight|watch-rotation>"
+  *) echo "Usage: duo <top|bottom|both|set-displays|toggle|status|set-tablet-mapping|bat-limit|sync-backlight|watch-backlight|watch-rotation|watch-displays>"
 esac

--- a/duo
+++ b/duo
@@ -28,7 +28,7 @@ function active-external-displays {
 
 case "$1" in
   watch-displays)
-    while inotifywait -e attrib /dev/bus/usb/001/ ; do
+    while inotifywait -e attrib /dev/bus/usb/*/ ; do
       if ! external-display-connected; then
         "$0" normal
       fi


### PR DESCRIPTION
- Added a watch-displays command 
- Changed the bottom screen toggle on GNOME section in the Readme.md to reflect [changes in linux kernel](https://discourse.nixos.org/t/asus-zenbook-duo-2024-ux8406ma-nixos/39792/114)

The watch-displays command functions similar to the watch-backlight command, only activating if the /dev/bus/usb/001/ directory was changed (e.g. by attaching/unattaching the keyboard), thus rarely overriding manual screen management.