### PR TITLE
watch-displays: take into account current orientation

### DIFF
--- a/duo
+++ b/duo
@@ -31,7 +31,8 @@ case "$1" in
   watch-displays)
     while inotifywait -e attrib /dev/bus/usb/*/ ; do
       if ! external-display-connected; then
-        "$0" normal
+        orientation=$(gdbus call --system --dest net.hadess.SensorProxy --object-path /net/hadess/SensorProxy --method org.freedesktop.DBus.Properties.Get net.hadess.SensorProxy AccelerometerOrientation | sed "s/.*<'\([^']*\)'>.*/\1/")
+        "$0" $orientation
       fi
     done
     ;;


### PR DESCRIPTION
This fixes the problem where when I work using booth screen but 90° rotated every time I plug/unplug a usb device it would switch back to the default orientation.